### PR TITLE
Make pacman output in english so it can properly be parsed

### DIFF
--- a/gem2arch.rb
+++ b/gem2arch.rb
@@ -117,7 +117,7 @@ class PkgBuild
       modified = true
       version_bump = true
       @release = 1
-      @content.gsub!(/pkgver=([\w\d\.]+)/, "pkgver=#{@version}")
+      @content.gsub!(/pkgver=([\w\.]+)/, "pkgver=#{@version}")
     end
 
     @content.gsub!(/pkgrel=\d+/, "pkgrel=#{@release}")
@@ -431,10 +431,6 @@ def check_gem_dependencies(dependencies)
       next
     end
 
-    # Fetch version information for the gem
-    dep = Gem::Dependency.new(d.name, nil)
-    dep_found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency(dep)
-    dep_spec, _ = dep_found.sort_by{ |(s,_)| s.version }.last
     unless d.requirement.satisfied_by?(Gem::Version.new(pkg.version))
       $stderr.puts "Package #{arch_name} version does not satisfy gem dependency"
     end


### PR DESCRIPTION
If LANGUAGE is set to some language other than english (e.g. "de"), the
following matches might fail. By setting LC_ALL=C we override all user settings.
