### PR TITLE
Added a PKGBUILD to install at /usr/bin/gem2arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gem2arch-*.pkg*

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,17 @@
+# gem2arch created by: Anatol Pomozov https://github.com/anatol
+# PKGBUILD added by: Johannes Ernst https://github.com/jernst
+
+pkgname=$(basename $(pwd))
+pkgver=0.11
+pkgrel=1
+pkgdesc='Simplifies creation and maintenance of RubyGem packages for Arch Linux'
+arch=('any')
+url='https://github.com/jernst/gem2arch'
+license=('GPLv3')
+depends=('ruby' 'ruby-erubis')
+
+package() {
+  mkdir -p ${pkgdir}/usr/bin
+  install -m755 ${startdir}/gem2arch.rb ${pkgdir}/usr/bin/gem2arch
+}
+


### PR DESCRIPTION
That makes it easier to invoke instead of having to remember where gem2arch.rb was located.