### PR TITLE
Add missing library

### DIFF
--- a/gem2arch.rb
+++ b/gem2arch.rb
@@ -3,6 +3,7 @@
 require 'digest/sha1'
 require 'erubis'
 require 'json'
+require 'net/http'
 require 'optparse'
 require 'ostruct'
 require 'rubygems/name_tuple'


### PR DESCRIPTION
Otherwise causes the following error on my machine:
```
/usr/bin/gem2arch:258:in `find_arch_version': uninitialized constant Net (NameError)

    resp = Net::HTTP.get_response(URI.parse(aur_request))
           ^^^
Did you mean?  Set
        from /usr/bin/gem2arch:427:in `block in check_gem_dependencies'
        from /usr/bin/gem2arch:424:in `each'
        from /usr/bin/gem2arch:424:in `check_gem_dependencies'
        from /usr/bin/gem2arch:459:in `gen_pkgbuild'
        from /usr/bin/gem2arch:517:in `create_packages'
        from /usr/bin/gem2arch:544:in `<main>'
```